### PR TITLE
Fix char missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,13 +70,7 @@ const listFilesOnCOS = (cos, nextMarker) => {
 const collectLocalFiles = async (cos) => {
     const root = cos.localPath;
     const files = new Set();
-    await walk(root, (path) => {
-        let p = path.substring(root.length);
-        for (;p[0] === '/';) {
-            p = p.substring(1);
-        }
-        files.add(p);
-    });
+    await walk(root, (path) => files.add(Path.relative(root,path)));
     return files;
 }
 


### PR DESCRIPTION
root 是 ./xxxx 时，path 是 Path.join("./xxxx","aaaa") 就是 xxxx/aaaa 
这个时候 .substring(root.lenght) 会多吃掉一个 char 直接用 Path 包的 relative 找相对关系就可以了
#22 
@mingshun @zqfan 